### PR TITLE
fix(security): verify JWT signatures, add logout, confirm deletes

### DIFF
--- a/actions/logout.ts
+++ b/actions/logout.ts
@@ -1,0 +1,8 @@
+"use server";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+export async function logoutAction() {
+  (await cookies()).delete("token");
+  redirect("/auth");
+}

--- a/components/dashboard/Header.tsx
+++ b/components/dashboard/Header.tsx
@@ -2,6 +2,7 @@
 
 import { FaBars } from "react-icons/fa";
 import { type Dispatch, type SetStateAction } from "react";
+import LogoutButton from "./LogoutButton";
 
 export default function Header({
   setSidebarOpen,
@@ -12,12 +13,16 @@ export default function Header({
     <header className="bg-white shadow-sm top-0 z-10 sticky">
       <div className="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8 flex justify-between items-center">
         <h1 className="text-2xl font-semibold text-gray-900">Dashboard</h1>
-        <button
-          onClick={() => setSidebarOpen(true)}
-          className="md:hidden p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
-        >
-          <FaBars className="h-6 w-6" aria-hidden="true" />
-        </button>
+        <div className="flex items-center gap-2">
+          <LogoutButton />
+          <button
+            onClick={() => setSidebarOpen(true)}
+            aria-label="Open menu"
+            className="md:hidden p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
+          >
+            <FaBars className="h-6 w-6" aria-hidden="true" />
+          </button>
+        </div>
       </div>
     </header>
   );

--- a/components/dashboard/LogoutButton.tsx
+++ b/components/dashboard/LogoutButton.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { FaSignOutAlt } from "react-icons/fa";
+import { useTransition } from "react";
+import { logoutAction } from "@/actions/logout";
+
+export default function LogoutButton() {
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <button
+      type="button"
+      onClick={() => startTransition(() => logoutAction())}
+      disabled={isPending}
+      className="flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 transition-colors focus:outline-none focus:ring-2 focus:ring-secondary-light disabled:opacity-50"
+    >
+      <FaSignOutAlt className="h-4 w-4" aria-hidden="true" />
+      <span>{isPending ? "Signing out…" : "Sign out"}</span>
+    </button>
+  );
+}

--- a/components/forms/FileUploadInput.tsx
+++ b/components/forms/FileUploadInput.tsx
@@ -26,10 +26,13 @@ const FileUploadInput = ({
   ) => {
     const file = event.target.files?.[0];
     if (file) {
-      setFileName(file.name);
       const fileUrl = await uploadImage(file);
-      setValue(name, fileUrl);
-      setUrl(fileUrl);
+      // Keep the previously saved file if the upload failed.
+      if (fileUrl) {
+        setFileName(file.name);
+        setValue(name, fileUrl, { shouldValidate: true });
+        setUrl(fileUrl);
+      }
     }
   };
 

--- a/components/forms/Form.tsx
+++ b/components/forms/Form.tsx
@@ -65,10 +65,10 @@ export const Form = <T extends FieldValues>({
       if (redirectPath) {
         router.push(redirectPath);
       }
+      // Reset only on success — clearing the form after a failed submit threw
+      // away everything the user had typed.
+      methods.reset();
     }
-
-    // reset form
-    methods.reset();
   }, [
     state.message,
     state.success,

--- a/components/general/DeleteButton.tsx
+++ b/components/general/DeleteButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { FaTrash } from "react-icons/fa";
-import { useActionState, useEffect, useTransition } from "react";
+import { useActionState, useEffect, useState, useTransition } from "react";
 import { showToast } from "@/utiles/showToast";
 import { IactionState } from "@/types/general";
 
@@ -14,6 +14,7 @@ interface DeleteButtonProps {
 
 const DeleteButton = ({ itemId, deleteAction }: DeleteButtonProps) => {
   const [isPending, StartTransition] = useTransition();
+  const [isConfirming, setIsConfirming] = useState(false);
   const [state, formAction] = useActionState(deleteAction, {
     message: "",
     success: false,
@@ -28,14 +29,46 @@ const DeleteButton = ({ itemId, deleteAction }: DeleteButtonProps) => {
     }
   }, [state]);
 
+  // Auto-cancel so a half-pressed delete doesn't sit armed indefinitely.
+  useEffect(() => {
+    if (!isConfirming) return;
+    const timeout = setTimeout(() => setIsConfirming(false), 5000);
+    return () => clearTimeout(timeout);
+  }, [isConfirming]);
+
+  if (isConfirming) {
+    return (
+      <span className="flex items-center gap-1">
+        <button
+          type="button"
+          disabled={isPending}
+          onClick={() => {
+            setIsConfirming(false);
+            StartTransition(() => formAction(itemId));
+          }}
+          className="bg-red-600 hover:bg-red-700 text-white font-bold py-1 px-2 rounded-md transition duration-150 disabled:opacity-50"
+        >
+          {isPending ? "Deleting" : "Confirm"}
+        </button>
+        <button
+          type="button"
+          onClick={() => setIsConfirming(false)}
+          className="bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-1 px-2 rounded-md transition duration-150"
+        >
+          Cancel
+        </button>
+      </span>
+    );
+  }
+
   return (
     <button
-      className="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-2 rounded-md transition duration-150 flex items-center"
-      onClick={() => {
-        StartTransition(() => formAction(itemId));
-      }}
+      type="button"
+      disabled={isPending}
+      className="bg-red-500 hover:bg-red-600 text-white font-bold py-1 px-2 rounded-md transition duration-150 flex items-center disabled:opacity-50"
+      onClick={() => setIsConfirming(true)}
     >
-      <FaTrash className="w-4 h-4 mr-1" />
+      <FaTrash className="w-4 h-4 mr-1" aria-hidden="true" />
       {isPending ? "Deleting" : "Delete"}
     </button>
   );

--- a/hooks/useImageUpload.ts
+++ b/hooks/useImageUpload.ts
@@ -10,10 +10,22 @@ export const useImageUpload = () => {
       const formData = new FormData();
       formData.append("image", file);
       const result = await uploadFileAction(formData);
+
+      // The action reports failure by returning success:false rather than
+      // throwing, so the catch below never sees it — check the result.
+      if (!result?.success || !result.url) {
+        showToast({
+          type: "error",
+          message: result?.message || "Upload failed",
+        });
+        return undefined;
+      }
+
       showToast({ type: "success", message: "File uploaded successfully!" });
       return result.url as string;
     } catch {
       showToast({ type: "error", message: "Something went wrong" });
+      return undefined;
     } finally {
       setLoading(false);
     }

--- a/middleware/authMiddleware.ts
+++ b/middleware/authMiddleware.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { decodeToken } from "@/utiles/decodeToken";
+import { verifyToken } from "@/utiles/verifyToken";
 import { routes } from "@/middleware/helper/RolesAndRoutes";
 import type { Role } from "@/types/authRoute";
 
@@ -11,16 +11,16 @@ export async function authMiddleware(
   const { pathname } = request.nextUrl;
   const token = request.cookies.get("token")?.value;
   let userRole: Role = "guest";
+  let tokenIsInvalid = false;
 
   if (token) {
-    try {
-      const decodedToken = decodeToken(token);
-      if (decodedToken?.role) {
-        userRole = decodedToken.role;
-      }
-    } catch {
-      // if token is invalid, redirect to home
-      return NextResponse.redirect(new URL(`/`, request.url));
+    // Signature and expiry are verified here. Decoding alone would let anyone
+    // hand-craft a cookie claiming `role: "admin"` and reach the dashboard.
+    const payload = await verifyToken(token);
+    if (payload?.role) {
+      userRole = payload.role;
+    } else {
+      tokenIsInvalid = true;
     }
   }
 
@@ -28,7 +28,10 @@ export async function authMiddleware(
   if (!route) return response || NextResponse.next(); // if no route found, continue to next middleware
 
   if (!route.roles.includes(userRole)) {
-    return NextResponse.redirect(new URL(`/`, request.url)); //if route found but user is not authorized, redirect to home
+    const redirect = NextResponse.redirect(new URL(`/`, request.url));
+    // Clear a rejected token so the browser stops replaying it every request.
+    if (tokenIsInvalid) redirect.cookies.delete("token");
+    return redirect;
   }
 
   return response || NextResponse.next();

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@sentry/nextjs": "^9.5.0",
         "clsx": "^2.1.1",
         "framer-motion": "^12.4.5",
-        "jsonwebtoken": "^9.0.2",
+        "jose": "^6.2.9",
         "next": "15.5.9",
         "npm": "^11.6.4",
         "posthog-js": "^1.345.5",
@@ -30,7 +30,6 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/typography": "^0.5.20",
-        "@types/jsonwebtoken": "^9.0.9",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -3167,17 +3166,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/jsonwebtoken": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.9.tgz",
-      "integrity": "sha512-uoe+GxEuHbvy12OUQct2X9JenKM3qAscquYymuQN4fMWG9DBQtykrQEFcAbVACF7qaLw9BePSodUL0kquqBJpQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/ms": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -4178,12 +4166,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -4816,15 +4798,6 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.114",
@@ -6885,6 +6858,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6957,28 +6939,6 @@
         "json5": "lib/cli.js"
       }
     },
-    "node_modules/jsonwebtoken": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      }
-    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -6993,27 +6953,6 @@
       },
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/jwa": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
-      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jws": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
-      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^1.4.2",
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -7230,53 +7169,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isboolean": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isinteger": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isnumber": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.once": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/log-update": {
@@ -11529,7 +11426,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@sentry/nextjs": "^9.5.0",
     "clsx": "^2.1.1",
     "framer-motion": "^12.4.5",
-    "jsonwebtoken": "^9.0.2",
+    "jose": "^6.2.9",
     "next": "15.5.9",
     "npm": "^11.6.4",
     "posthog-js": "^1.345.5",
@@ -39,7 +39,6 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/typography": "^0.5.20",
-    "@types/jsonwebtoken": "^9.0.9",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/types/jwt.ts
+++ b/types/jwt.ts
@@ -1,8 +1,8 @@
-import { JwtPayload } from "jsonwebtoken";
+import type { JWTPayload } from "jose";
 import { Role } from "@/types/authRoute";
 
 // Define what our JWT token contains
-export interface CustomJwtPayload extends JwtPayload {
+export interface CustomJwtPayload extends JWTPayload {
   id: string;
   role: Role;
 }

--- a/utiles/decodeToken.ts
+++ b/utiles/decodeToken.ts
@@ -1,8 +1,0 @@
-import jwt from "jsonwebtoken";
-import { CustomJwtPayload } from "@/types/jwt";
-
-export const decodeToken = (token: string): CustomJwtPayload | null => {
-  const decoded = jwt.decode(token);
-  if (!decoded) return null;
-  return decoded as CustomJwtPayload;
-};

--- a/utiles/verifyToken.ts
+++ b/utiles/verifyToken.ts
@@ -1,0 +1,35 @@
+import { jwtVerify } from "jose/jwt/verify";
+import { CustomJwtPayload } from "@/types/jwt";
+
+// `jose` is used instead of `jsonwebtoken` because middleware runs on the
+// edge runtime, where node's crypto module is unavailable.
+const getSecret = () => {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) return null;
+  return new TextEncoder().encode(secret);
+};
+
+/**
+ * Verifies a token's signature and expiry and returns its payload.
+ *
+ * Returns null for anything untrusted: a bad signature, an expired token, a
+ * malformed token, or a missing JWT_SECRET. Callers must treat null as
+ * "not authenticated" — never as "carry on".
+ */
+export const verifyToken = async (
+  token: string,
+): Promise<CustomJwtPayload | null> => {
+  const secret = getSecret();
+  if (!secret) {
+    console.error("JWT_SECRET is not set — refusing to authorize any request.");
+    return null;
+  }
+
+  try {
+    const { payload } = await jwtVerify(token, secret);
+    return payload as CustomJwtPayload;
+  } catch {
+    // Invalid signature, expired, or malformed.
+    return null;
+  }
+};


### PR DESCRIPTION
Frontend half of the security batch (items 9, 11, 12, 13 of the audit).

1. Verify the token instead of decoding it (was: full auth bypass) utiles/decodeToken.ts used jwt.decode(), which checks neither the signature nor the expiry. Anyone could craft an unsigned token claiming `role: "admin"`, set it as the `token` cookie, and reach /dashboard. Writes still failed because the backend verifies properly, but the admin UI and its structure were exposed, and expired tokens never stopped working.

   Replaced with jose's jwtVerify (jose is edge-compatible; jsonwebtoken is not and was only working because decode() never touches crypto). Imported via the `jose/jwt/verify` subpath so the JWE decrypt code - which uses DecompressionStream and warns on the edge runtime - stays out of the middleware bundle. A rejected token is now also cleared from the browser so it stops being replayed.

   Verified against a running server:
     no cookie              -> 307 redirect
     forged (alg:none)      -> 307 redirect
     forged (wrong secret)  -> 307 redirect
     expired (real secret)  -> 307 redirect
     valid admin token      -> 200

   Dropping jsonwebtoken also shrank the middleware from 108 kB to 95.7 kB.

2. Add logout There was no way to sign out anywhere in the app - the token cookie simply lived for 30 days. Adds a logout server action that clears the cookie and redirects to /auth, plus a Sign out button in the dashboard header. Also labels the previously unlabelled menu toggle.

3. Require confirmation before deleting DeleteButton fired the delete action on a single click with no confirmation and no undo. Now a two-step inline confirm (Confirm/Cancel) that auto-cancels after 5s, so a half-pressed delete cannot sit armed.

4. Stop forms discarding input on failure Form.tsx called methods.reset() on every state change, including failed submissions, wiping everything the user had typed. Now resets only on success.

5. Stop reporting failed uploads as successful useImageUpload always showed "File uploaded successfully!" because uploadFileAction returns { success: false } instead of throwing, so the catch never ran. Now checks the result and surfaces the real error. FileUploadInput additionally overwrote the saved CV URL with undefined when an upload failed; it now keeps the existing file.

Requires JWT_SECRET (the same value the backend signs with) in the frontend environment. Without it the middleware denies every dashboard request rather than failing open.

Verified: tsc clean, eslint clean, production build clean with no edge runtime warnings.