### PR TITLE
feat: add route loading/error/404 states and reduce-motion support

### DIFF
--- a/app/(dashboard)/dashboard/error.tsx
+++ b/app/(dashboard)/dashboard/error.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+import * as Sentry from "@sentry/nextjs";
+import { FaRedo } from "react-icons/fa";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <div className="bg-white shadow-md rounded-lg px-8 pt-6 pb-8 mb-4">
+      <h2 className="text-2xl font-semibold mb-2 text-gray-800">
+        Something went wrong
+      </h2>
+      <p className="text-gray-600 mb-6">
+        This page failed to load. Your data has not been changed.
+      </p>
+      <button
+        onClick={reset}
+        className="inline-flex items-center gap-2 bg-secondary-light hover:bg-secondary-dark text-white font-medium py-2 px-4 rounded-lg transition-colors"
+      >
+        <FaRedo aria-hidden="true" />
+        Try again
+      </button>
+      {error.digest && (
+        <p className="mt-6 text-xs text-gray-400">Reference: {error.digest}</p>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/loading.tsx
+++ b/app/(dashboard)/dashboard/loading.tsx
@@ -1,0 +1,23 @@
+// Skeleton for the dashboard's data-backed pages.
+export default function Loading() {
+  return (
+    <div
+      className="bg-white shadow-md rounded-lg px-8 pt-6 pb-8 mb-4 animate-pulse"
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <span className="sr-only">Loading…</span>
+      <div className="h-7 w-56 rounded bg-gray-200 mb-6" />
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="rounded-xl border border-gray-100 p-4">
+            <div className="h-48 w-full rounded-lg bg-gray-200 mb-4" />
+            <div className="h-5 w-2/3 rounded bg-gray-200 mb-2" />
+            <div className="h-3 w-full rounded bg-gray-100 mb-1" />
+            <div className="h-3 w-5/6 rounded bg-gray-100" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/error.tsx
+++ b/app/(main)/error.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect } from "react";
+import * as Sentry from "@sentry/nextjs";
+import { FaRedo, FaHome } from "react-icons/fa";
+import Link from "next/link";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-[60vh] flex flex-col items-center justify-center text-center px-4">
+      <div className="rounded-2xl border border-red-500/30 bg-[#0f172a]/80 backdrop-blur-xl p-8 md:p-12 max-w-lg">
+        <h1 className="text-2xl md:text-3xl font-bold mb-3 bg-gradient-to-r from-red-400 to-purple-400 bg-clip-text text-transparent">
+          Something went wrong
+        </h1>
+        <p className="text-gray-400 mb-8">
+          This section failed to load. Trying again usually fixes it.
+        </p>
+
+        <div className="flex flex-wrap gap-3 justify-center">
+          <button
+            onClick={reset}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-md bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-500 hover:to-purple-500 transition-colors"
+          >
+            <FaRedo aria-hidden="true" />
+            Try again
+          </button>
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-md bg-white/5 hover:bg-white/10 border border-white/10 transition-colors"
+          >
+            <FaHome aria-hidden="true" />
+            Go home
+          </Link>
+        </div>
+
+        {error.digest && (
+          <p className="mt-6 text-xs text-gray-600">
+            Reference: {error.digest}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/loading.tsx
+++ b/app/(main)/loading.tsx
@@ -1,0 +1,34 @@
+// Shown while a public page's data is fetched, instead of a blank pause.
+export default function Loading() {
+  return (
+    <div className="animate-pulse" aria-busy="true" aria-live="polite">
+      <span className="sr-only">Loading…</span>
+
+      {/* Mirrors the <Title /> block */}
+      <div className="ml-[20px] mb-8">
+        <div className="h-9 md:h-10 w-56 rounded-md bg-white/10" />
+        <div className="mt-5 h-[5px] w-[150px] rounded-md bg-blue-500/20" />
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="rounded-xl border-2 border-blue-500/20 bg-gradient-to-br from-[#0D1127] to-[#1a1f3c] overflow-hidden"
+          >
+            <div className="h-[200px] w-full bg-white/5" />
+            <div className="p-6 space-y-3">
+              <div className="h-5 w-2/3 rounded bg-white/10" />
+              <div className="h-3 w-full rounded bg-white/5" />
+              <div className="h-3 w-5/6 rounded bg-white/5" />
+              <div className="flex gap-3 pt-2">
+                <div className="h-9 w-24 rounded-md bg-white/5" />
+                <div className="h-9 w-24 rounded-md bg-white/5" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,10 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
-*{
-  font-family: var(--main-font);;
+* {
+  font-family: var(--main-font);
 }
-html,body,main{
+html,
+body,
+main {
   overflow-x: hidden;
 }
 /* Main App Scrollbar */
@@ -34,7 +36,6 @@ html,body,main{
   background-clip: content-box;
 }
 
-
 @layer base {
   .input-light {
     @apply !bg-white !text-gray-800 !border-gray-300 !placeholder-gray-500;
@@ -42,5 +43,18 @@ html,body,main{
 
   .input-dark {
     @apply !bg-gray-800/30 !text-gray-200 !border-gray-700/50 !placeholder-gray-400;
+  }
+}
+
+/* Honour the OS "reduce motion" setting for CSS-driven animation.
+   framer-motion is handled separately by MotionConfig in MotionProvider. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { Metadata } from "next";
 import { Person, WithContext } from "schema-dts";
 import ChatBotWraper from "@/components/general/chatbot/ChatBotWraper";
 import CanvasCursor from "@/components/general/CanvasCursor";
+import MotionProvider from "@/app/providers/MotionProvider";
 import { siteDescription, siteName, siteUrl } from "@/utiles/site";
 import "./globals.css";
 // metadata
@@ -90,7 +91,7 @@ export default async function RootLayout({
           theme="light"
           className="z[1000]"
         />
-        {children}
+        <MotionProvider>{children}</MotionProvider>
         <CanvasCursor />
         <ChatBotWraper />
       </body>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { Metadata } from "next";
+import { FaHome } from "react-icons/fa";
+
+export const metadata: Metadata = {
+  title: "Page not found",
+};
+
+// Root-level 404. Unmatched URLs render here, outside the (main) layout, so
+// this page carries its own full-screen styling.
+export default function NotFound() {
+  return (
+    <main className="min-h-dvh flex flex-col items-center justify-center bg-primary-light text-white text-center px-4">
+      <p className="text-7xl md:text-9xl font-bold bg-gradient-to-r from-cyan-400 to-purple-500 bg-clip-text text-transparent">
+        404
+      </p>
+      <h1 className="mt-4 text-2xl md:text-3xl font-bold">Page not found</h1>
+      <p className="mt-3 text-gray-400 max-w-md">
+        The page you are looking for doesn&apos;t exist or has been moved.
+      </p>
+      <Link
+        href="/"
+        className="mt-8 inline-flex items-center gap-2 px-6 py-3 rounded-md bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-500 hover:to-purple-500 transition-colors"
+      >
+        <FaHome aria-hidden="true" />
+        Back to home
+      </Link>
+    </main>
+  );
+}

--- a/app/providers/MotionProvider.tsx
+++ b/app/providers/MotionProvider.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { MotionConfig } from "framer-motion";
+import { type ReactNode } from "react";
+
+/**
+ * Makes every framer-motion animation in the app honour the operating
+ * system's "reduce motion" setting.
+ *
+ * CSS-only animations are handled separately by the prefers-reduced-motion
+ * block in globals.css — framer-motion animates inline styles from JS, so a
+ * media query cannot reach it.
+ *
+ * `children` stays server-rendered: it is passed through as a prop, so this
+ * client boundary does not pull the page into the client bundle.
+ */
+export default function MotionProvider({ children }: { children: ReactNode }) {
+  return <MotionConfig reducedMotion="user">{children}</MotionConfig>;
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,11 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
+  // Generated output — linting it reported thousands of errors from files
+  // nobody edits.
+  {
+    ignores: [".next/**", "next-env.d.ts", "node_modules/**"],
+  },
   ...compat.extends("next/core-web-vitals", "next/typescript"),
   {
     rules: {

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,10 +6,6 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: "https",
-        hostname: "res.cloudinary.com",
-      },
-      {
-        protocol: "https",
         hostname: "dev-mahmoud.sirv.com",
         pathname: "**",
       },


### PR DESCRIPTION
Items 15, 16 (partial) and two small cleanups from the audit.

1. Route-level loading, error and 404 states The app had only global-error.tsx, so every navigation was a blank pause with no skeleton, and any bad URL fell through to Next's unstyled default 404 rendered outside the site's layout.

   Adds:
     app/(main)/loading.tsx              skeleton matching the Title + card grid
     app/(main)/error.tsx                retry / go home, reports to Sentry
     app/not-found.tsx                   styled 404 in the site's palette
     app/(dashboard)/dashboard/loading.tsx
     app/(dashboard)/dashboard/error.tsx

   Both error boundaries call Sentry.captureException, so a page-level crash is now reported rather than silently swallowed. Skeletons carry aria-busy and an sr-only "Loading…" label.

2. Honour the OS "reduce motion" setting The site animates heavily and continuously, with no reduced-motion path at all. Two mechanisms are needed because the animation comes from two places:

     - framer-motion animates inline styles from JS, which a media query
       cannot reach, so MotionProvider wraps the tree in
       <MotionConfig reducedMotion="user">. `children` is passed as a prop, so
       the pages stay server-rendered — home grew 8.4 kB -> 8.91 kB.
     - CSS animation and transitions (animate-pulse, animate-bounce,
       animate-spin, transition-*) are covered by a prefers-reduced-motion
       block in globals.css.

   This does not change the default appearance. Trimming the always-on animations for everyone is a separate, deliberately visual decision and is not part of this PR.

3. Drop the dead Cloudinary image host next.config.ts still allowed res.cloudinary.com from the May 2025 upload migration. All 40 image URLs in the database are on Sirv; there are no Cloudinary URLs left, so the pattern only widened what could feed the image optimizer.

4. Stop ESLint linting generated output eslint.config.mjs had no ignores, so `npx eslint .` reported 3199 errors from .next/** and next-env.d.ts. `npm run lint` hid this because next lint ignores those by default. Now zero errors across the whole repo.

Verified: tsc clean, `eslint .` clean, production build clean, /unknown-url returns a real 404 with the styled page, and all public routes still 200 with one <main> and one <h1>.