### PR TITLE
feat(a11y): label form fields, add field variants, harden mobile drawer

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,22 +1,70 @@
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
-import NextError from "next/error";
 import { useEffect } from "react";
 
+/**
+ * Last-resort boundary: catches errors in the root layout itself, so it has to
+ * render its own <html> and <body>.
+ *
+ * Deliberately does NOT use `next/error`. That is a pages-router component, so
+ * rendering it makes the build resolve /_document, which fails in an
+ * app-router-only project ("Cannot find module for page: /_document") whenever
+ * chunking shifts. It also rendered a bare, unstyled page with statusCode 0.
+ */
 export default function GlobalError({
   error,
+  reset,
 }: {
   error: Error & { digest?: string };
+  reset: () => void;
 }) {
   useEffect(() => {
     Sentry.captureException(error);
   }, [error]);
 
   return (
-    <html>
-      <body>
-        <NextError statusCode={0} />
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "1rem",
+          textAlign: "center",
+          padding: "1.5rem",
+          backgroundColor: "#0a1326",
+          color: "#ffffff",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        <h1 style={{ fontSize: "1.75rem", margin: 0 }}>Something went wrong</h1>
+        <p style={{ color: "#94a3b8", margin: 0, maxWidth: "32rem" }}>
+          An unexpected error occurred. Reloading usually fixes it.
+        </p>
+        <button
+          onClick={reset}
+          style={{
+            marginTop: "0.5rem",
+            padding: "0.75rem 1.5rem",
+            borderRadius: "0.375rem",
+            border: "none",
+            cursor: "pointer",
+            color: "#ffffff",
+            backgroundColor: "#2563eb",
+            fontSize: "1rem",
+          }}
+        >
+          Try again
+        </button>
+        {error.digest && (
+          <p style={{ color: "#475569", fontSize: "0.75rem", margin: 0 }}>
+            Reference: {error.digest}
+          </p>
+        )}
       </body>
     </html>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -36,16 +36,6 @@ main {
   background-clip: content-box;
 }
 
-@layer base {
-  .input-light {
-    @apply !bg-white !text-gray-800 !border-gray-300 !placeholder-gray-500;
-  }
-
-  .input-dark {
-    @apply !bg-gray-800/30 !text-gray-200 !border-gray-700/50 !placeholder-gray-400;
-  }
-}
-
 /* Honour the OS "reduce motion" setting for CSS-driven animation.
    framer-motion is handled separately by MotionConfig in MotionProvider. */
 @media (prefers-reduced-motion: reduce) {

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -23,17 +23,12 @@ const LoginForm = () => {
             name: "Sign In",
           }}
         >
-          <InputField
-            name="email"
-            label="Email"
-            type="email"
-            className="bg-text-primary"
-          />
+          <InputField name="email" label="Email" type="email" variant="light" />
           <InputField
             name="password"
             label="Password"
             type="password"
-            className="bg-text-primary"
+            variant="light"
           />
         </Form>
       </div>

--- a/components/dashboard/education/AddEducationForm.tsx
+++ b/components/dashboard/education/AddEducationForm.tsx
@@ -27,37 +27,32 @@ const AddEducationForm = () => {
       }}
     >
       <div className="grid grid-cols-1 gap-6">
-        <InputField
-          name="degree"
-          label="Degree"
-          type="text"
-          className="input-light"
-        />
+        <InputField name="degree" label="Degree" type="text" variant="light" />
         <InputField
           name="institution"
           label="Institution"
           type="text"
-          className="input-light"
+          variant="light"
         />
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <InputField
             name="startDate"
             label="Start Date"
             type="text"
-            className="input-light"
+            variant="light"
           />
           <InputField
             name="endDate"
             label="End Date"
             type="text"
-            className="input-light"
+            variant="light"
           />
         </div>
         <InputField
           name="skills"
           label="Skills (comma-separated, e.g. JavaScript, Python)"
           type="text"
-          className="input-light"
+          variant="light"
         />
         <ImageUploadInput
           name="image"
@@ -68,7 +63,7 @@ const AddEducationForm = () => {
           name="description"
           label="Description"
           rows={6}
-          className="input-light"
+          variant="light"
         />
       </div>
     </Form>

--- a/components/dashboard/education/EditEducationForm.tsx
+++ b/components/dashboard/education/EditEducationForm.tsx
@@ -42,37 +42,32 @@ const EditEducationForm = ({
     >
       <div className="grid grid-cols-1 gap-6">
         <EducationIdField id={education._id} />
-        <InputField
-          name="degree"
-          label="Degree"
-          type="text"
-          className="input-light"
-        />
+        <InputField name="degree" label="Degree" type="text" variant="light" />
         <InputField
           name="institution"
           label="Institution"
           type="text"
-          className="input-light"
+          variant="light"
         />
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <InputField
             name="startDate"
             label="Start Date"
             type="text"
-            className="input-light"
+            variant="light"
           />
           <InputField
             name="endDate"
             label="End Date"
             type="text"
-            className="input-light"
+            variant="light"
           />
         </div>
         <InputField
           name="skills"
           label="Skills (comma-separated, e.g. JavaScript, Python)"
           type="text"
-          className="input-light"
+          variant="light"
         />
         <ImageUploadInput
           name="image"
@@ -83,7 +78,7 @@ const EditEducationForm = ({
           name="description"
           label="Description"
           rows={6}
-          className="input-light"
+          variant="light"
         />
       </div>
     </Form>

--- a/components/dashboard/experience/AddExperienceForm.tsx
+++ b/components/dashboard/experience/AddExperienceForm.tsx
@@ -33,40 +33,40 @@ const AddExperienceForm = () => {
             name="role"
             label="Role / Title"
             type="text"
-            className="input-light"
+            variant="light"
           />
           <InputField
             name="workType"
             label="Work Type (e.g. Remote, Hybrid)"
             type="text"
-            className="input-light"
+            variant="light"
           />
         </div>
         <InputField
           name="company"
           label="Company"
           type="text"
-          className="input-light"
+          variant="light"
         />
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <InputField
             name="startDate"
             label="Start Date"
             type="text"
-            className="input-light"
+            variant="light"
           />
           <InputField
             name="endDate"
             label="End Date"
             type="text"
-            className="input-light"
+            variant="light"
           />
         </div>
         <InputField
           name="skills"
           label="Skills (comma-separated, e.g. React, Node.js)"
           type="text"
-          className="input-light"
+          variant="light"
         />
         <ImageUploadInput
           name="image"
@@ -77,7 +77,7 @@ const AddExperienceForm = () => {
           name="description"
           label="Description"
           rows={6}
-          className="input-light"
+          variant="light"
         />
       </div>
     </Form>

--- a/components/dashboard/experience/EditExperienceForm.tsx
+++ b/components/dashboard/experience/EditExperienceForm.tsx
@@ -48,40 +48,40 @@ const EditExperienceForm = ({
             name="role"
             label="Role / Title"
             type="text"
-            className="input-light"
+            variant="light"
           />
           <InputField
             name="workType"
             label="Work Type (e.g. Remote, Hybrid)"
             type="text"
-            className="input-light"
+            variant="light"
           />
         </div>
         <InputField
           name="company"
           label="Company"
           type="text"
-          className="input-light"
+          variant="light"
         />
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <InputField
             name="startDate"
             label="Start Date"
             type="text"
-            className="input-light"
+            variant="light"
           />
           <InputField
             name="endDate"
             label="End Date"
             type="text"
-            className="input-light"
+            variant="light"
           />
         </div>
         <InputField
           name="skills"
           label="Skills (comma-separated, e.g. React, Node.js)"
           type="text"
-          className="input-light"
+          variant="light"
         />
         <ImageUploadInput
           name="image"
@@ -92,7 +92,7 @@ const EditExperienceForm = ({
           name="description"
           label="Description"
           rows={6}
-          className="input-light"
+          variant="light"
         />
       </div>
     </Form>

--- a/components/dashboard/personal-data/PersonalForm.tsx
+++ b/components/dashboard/personal-data/PersonalForm.tsx
@@ -22,60 +22,40 @@ const PersonalForm = ({
       }}
     >
       <div className="grid grid-cols-1 gap-6">
-        <InputField
-          name="userName"
-          label="Name"
-          type="text"
-          className="input-light"
-        />
-        <InputField
-          name="title"
-          label="Title"
-          type="text"
-          className="input-light"
-        />
-        <InputField
-          name="email"
-          label="Email"
-          type="email"
-          className="input-light"
-        />
+        <InputField name="userName" label="Name" type="text" variant="light" />
+        <InputField name="title" label="Title" type="text" variant="light" />
+        <InputField name="email" label="Email" type="email" variant="light" />
         <InputField
           name="address"
           label="Address"
           type="text"
-          className="input-light"
+          variant="light"
         />
         <InputField
           name="phone1"
           label="Phone number 1"
           type="text"
-          className="input-light"
+          variant="light"
         />
         <InputField
           name="phone2"
           label="Phone number 2"
           type="text"
-          className="input-light"
+          variant="light"
         />
-        <TextArea name="bio" label="Bio" rows={6} className="input-light" />
-        <InputField
-          name="github"
-          label="Github"
-          type="text"
-          className="input-light"
-        />
+        <TextArea name="bio" label="Bio" rows={6} variant="light" />
+        <InputField name="github" label="Github" type="text" variant="light" />
         <InputField
           name="linkedin"
           label="LinkedIn"
           type="text"
-          className="input-light"
+          variant="light"
         />
         <ImageUploadInput
           name="avatar"
           label="Upload avatar Image"
           type="image"
-          className="input-light"
+          variant="light"
         />
         <ImageUploadInput
           name="aboutImage"

--- a/components/dashboard/projects/AddProjectForm.tsx
+++ b/components/dashboard/projects/AddProjectForm.tsx
@@ -29,31 +29,31 @@ const AddProjectForm = () => {
           name="title"
           label="Title of Project"
           type="text"
-          className="input-light"
+          variant="light"
         />
         <TextArea
           name="description"
           label="Description of Project"
           rows={8}
-          className="input-light"
+          variant="light"
         />
         <InputField
           name="demoLink"
           label="Demo Link"
           type="text"
-          className="input-light"
+          variant="light"
         />
         <InputField
           name="githubLink"
           label="Github Link"
           type="text"
-          className="input-light"
+          variant="light"
         />
         <InputField
           name="order"
           label="Display Order"
           type="number"
-          className="input-light"
+          variant="light"
         />
         <ImageUploadInput name="imageUrl" label="Upload project image" />
       </div>

--- a/components/dashboard/projects/EditProjectForm.tsx
+++ b/components/dashboard/projects/EditProjectForm.tsx
@@ -22,31 +22,31 @@ const EditProjectForm = ({ initialValues }: { initialValues: Iproject }) => {
           name="title"
           label="Title of Project"
           type="text"
-          className="input-light"
+          variant="light"
         />
         <TextArea
           name="description"
           label="Description of Project"
           rows={8}
-          className="input-light"
+          variant="light"
         />
         <InputField
           name="demoLink"
           label="Demo Link"
           type="text"
-          className="input-light"
+          variant="light"
         />
         <InputField
           name="githubLink"
           label="Github Link"
           type="text"
-          className="input-light"
+          variant="light"
         />
         <InputField
           name="order"
           label="Display Order"
           type="number"
-          className="input-light"
+          variant="light"
         />
         <ImageUploadInput name="imageUrl" label="Upload project image" />
       </div>

--- a/components/dashboard/skills/AddSkillForm.tsx
+++ b/components/dashboard/skills/AddSkillForm.tsx
@@ -24,7 +24,7 @@ const AddSkillForm = () => {
           name="name"
           label="Name of skill"
           type="text"
-          className="input-light"
+          variant="light"
         />
         <ImageUploadInput name="imageUrl" label="Upload skill image" />
       </div>

--- a/components/dashboard/skills/EditSkill.tsx
+++ b/components/dashboard/skills/EditSkill.tsx
@@ -21,7 +21,7 @@ const EditSkillForm = ({ initialValues }: { initialValues: ISkill }) => {
           name="name"
           label="Name of skill"
           type="text"
-          className="input-light"
+          variant="light"
         />
         <ImageUploadInput name="imageUrl" label="Upload skill image" />
       </div>

--- a/components/forms/FileUploadInput.tsx
+++ b/components/forms/FileUploadInput.tsx
@@ -44,7 +44,9 @@ const FileUploadInput = ({
 
   return (
     <div className="flex flex-col gap-2">
-      <label className="text-gray-700">{label}</label>
+      <label htmlFor={name} className="text-gray-700">
+        {label}
+      </label>
       <div
         className={`border border-dashed border-gray-400 rounded-md p-4 h-[200px] flex items-center justify-center ${className}`}
       >

--- a/components/forms/ImageUploadInput.tsx
+++ b/components/forms/ImageUploadInput.tsx
@@ -34,7 +34,9 @@ const ImageUploadInput = ({ name, label, className }: InputFieldProps) => {
 
   return (
     <div className="flex flex-col gap-2">
-      <label className="text-gray-700">{label}</label>
+      <label htmlFor={`file-picker-${name}`} className="text-gray-700">
+        {label}
+      </label>
       {/* Hidden input registered with RHF to hold the URL value */}
       <input type="hidden" {...register(name)} />
       <div

--- a/components/forms/InputField.tsx
+++ b/components/forms/InputField.tsx
@@ -4,19 +4,32 @@ import { InputFieldProps } from "@/types/forms";
 import clsx from "clsx";
 import { motion } from "framer-motion";
 import { useState } from "react";
+import {
+  fieldBase,
+  fieldError,
+  fieldVariants,
+  labelVariants,
+} from "./fieldStyles";
 
 const InputField = ({
   name,
   label,
   className,
   type = "text",
-  value,
+  variant = "dark",
+  showLabel,
 }: InputFieldProps) => {
   const {
     register,
     formState: { errors },
   } = useFormContext();
   const [isHovered, setIsHovered] = useState(false);
+
+  // Dashboard fields show their label; the public site keeps its cleaner look
+  // and exposes the label to assistive tech only.
+  const labelIsVisible = showLabel ?? variant === "light";
+  const errorId = `${name}-error`;
+  const hasError = Boolean(errors[name]);
 
   return (
     <motion.div
@@ -25,6 +38,19 @@ const InputField = ({
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3 }}
     >
+      {/* Always rendered: a placeholder is not an accessible name, and it
+          disappears as soon as the user types. */}
+      <label
+        htmlFor={name}
+        className={clsx(
+          labelIsVisible
+            ? clsx("text-sm font-medium", labelVariants[variant])
+            : "sr-only",
+        )}
+      >
+        {label}
+      </label>
+
       <motion.div
         whileTap={{ scale: 0.98 }}
         animate={{
@@ -36,42 +62,42 @@ const InputField = ({
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       >
-        <motion.div
-          className="absolute inset-0 bg-gradient-to-r from-blue-500/10 to-purple-500/10"
-          animate={{
-            opacity: isHovered ? 1 : 0,
-          }}
-          transition={{ duration: 0.3 }}
-        />
+        {variant === "dark" && (
+          <motion.div
+            className="absolute inset-0 bg-gradient-to-r from-blue-500/10 to-purple-500/10 pointer-events-none"
+            animate={{ opacity: isHovered ? 1 : 0 }}
+            transition={{ duration: 0.3 }}
+          />
+        )}
         <input
           {...register(name)}
+          id={name}
           type={type}
+          placeholder={label}
+          aria-invalid={hasError || undefined}
+          aria-describedby={hasError ? errorId : undefined}
           className={clsx(
-            "w-full px-4 py-3 rounded-lg",
-            "border-2 border-gray-700/50",
-            "bg-gray-800/30 backdrop-blur-sm",
-            "text-gray-200 placeholder-gray-400",
-            "transition-all duration-300",
-            "focus:outline-none focus:border-blue-500",
-            "focus:ring-2 focus:ring-blue-500/20",
-            "hover:border-gray-600",
-            errors[name] &&
-              "border-red-500 focus:border-red-500 focus:ring-red-500/20",
+            fieldBase,
+            fieldVariants[variant],
+            hasError && fieldError,
             className,
           )}
-          placeholder={label}
-          value={value}
         />
       </motion.div>
 
-      {errors[name] && (
+      {hasError && (
         <motion.p
+          id={errorId}
+          role="alert"
           className="text-red-500 text-sm pl-2 flex items-center gap-2"
           initial={{ opacity: 0, x: -20 }}
           animate={{ opacity: 1, x: 0 }}
           exit={{ opacity: 0, x: -20 }}
         >
-          <span className="inline-block w-1 h-1 bg-red-500 rounded-full" />
+          <span
+            aria-hidden="true"
+            className="inline-block w-1 h-1 bg-red-500 rounded-full"
+          />
           {errors[name]?.message as string}
         </motion.p>
       )}

--- a/components/forms/TextArea.tsx
+++ b/components/forms/TextArea.tsx
@@ -4,13 +4,30 @@ import { useFormContext } from "react-hook-form";
 import { TextAreaProps } from "@/types/forms";
 import clsx from "clsx";
 import { motion } from "framer-motion";
+import {
+  fieldBase,
+  fieldError,
+  fieldVariants,
+  labelVariants,
+} from "./fieldStyles";
 
-const TextArea = ({ name, label, rows = 4, className = "" }: TextAreaProps) => {
+const TextArea = ({
+  name,
+  label,
+  rows = 4,
+  className = "",
+  variant = "dark",
+  showLabel,
+}: TextAreaProps) => {
   const {
     register,
     formState: { errors },
   } = useFormContext();
   const [isHovered, setIsHovered] = useState(false);
+
+  const labelIsVisible = showLabel ?? variant === "light";
+  const errorId = `${name}-error`;
+  const hasError = Boolean(errors[name]);
 
   return (
     <motion.div
@@ -19,6 +36,17 @@ const TextArea = ({ name, label, rows = 4, className = "" }: TextAreaProps) => {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3 }}
     >
+      <label
+        htmlFor={name}
+        className={clsx(
+          labelIsVisible
+            ? clsx("text-sm font-medium", labelVariants[variant])
+            : "sr-only",
+        )}
+      >
+        {label}
+      </label>
+
       <motion.div
         whileTap={{ scale: 0.98 }}
         animate={{
@@ -30,42 +58,43 @@ const TextArea = ({ name, label, rows = 4, className = "" }: TextAreaProps) => {
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       >
-        <motion.div
-          className="absolute inset-0 bg-gradient-to-r from-blue-500/10 to-purple-500/10"
-          animate={{
-            opacity: isHovered ? 1 : 0,
-          }}
-          transition={{ duration: 0.3 }}
-        />
+        {variant === "dark" && (
+          <motion.div
+            className="absolute inset-0 bg-gradient-to-r from-blue-500/10 to-purple-500/10 pointer-events-none"
+            animate={{ opacity: isHovered ? 1 : 0 }}
+            transition={{ duration: 0.3 }}
+          />
+        )}
         <textarea
           {...register(name)}
+          id={name}
           rows={rows}
+          placeholder={label}
+          aria-invalid={hasError || undefined}
+          aria-describedby={hasError ? errorId : undefined}
           className={clsx(
-            "w-full px-4 py-3 rounded-lg",
-            "border-2 border-gray-700/50",
-            "bg-gray-800/30 backdrop-blur-sm",
-            "text-gray-200 placeholder-gray-400",
-            "transition-all duration-300",
-            "focus:outline-none focus:border-blue-500",
-            "focus:ring-2 focus:ring-blue-500/20",
-            "hover:border-gray-600",
+            fieldBase,
+            fieldVariants[variant],
             "resize-none",
-            errors[name] &&
-              "border-red-500 focus:border-red-500 focus:ring-red-500/20",
+            hasError && fieldError,
             className,
           )}
-          placeholder={label}
         />
       </motion.div>
 
-      {errors[name] && (
+      {hasError && (
         <motion.p
+          id={errorId}
+          role="alert"
           className="text-red-500 text-sm pl-2 flex items-center gap-2"
           initial={{ opacity: 0, x: -20 }}
           animate={{ opacity: 1, x: 0 }}
           exit={{ opacity: 0, x: -20 }}
         >
-          <span className="inline-block w-1 h-1 bg-red-500 rounded-full" />
+          <span
+            aria-hidden="true"
+            className="inline-block w-1 h-1 bg-red-500 rounded-full"
+          />
           {errors[name]?.message as string}
         </motion.p>
       )}

--- a/components/forms/fieldStyles.ts
+++ b/components/forms/fieldStyles.ts
@@ -1,0 +1,29 @@
+import { FieldVariant } from "@/types/forms";
+
+// Shared by InputField and TextArea so the two surfaces stay in sync.
+export const fieldBase = [
+  "w-full px-4 py-3 rounded-lg border-2",
+  "transition-all duration-300",
+  "focus:outline-none focus:ring-2",
+].join(" ");
+
+export const fieldVariants: Record<FieldVariant, string> = {
+  dark: [
+    "bg-gray-800/30 backdrop-blur-sm text-gray-200 placeholder-gray-400",
+    "border-gray-700/50 hover:border-gray-600",
+    "focus:border-blue-500 focus:ring-blue-500/20",
+  ].join(" "),
+  light: [
+    "bg-white text-gray-800 placeholder-gray-500",
+    "border-gray-300 hover:border-gray-400",
+    "focus:border-blue-500 focus:ring-blue-500/20",
+  ].join(" "),
+};
+
+export const fieldError =
+  "border-red-500 focus:border-red-500 focus:ring-red-500/20";
+
+export const labelVariants: Record<FieldVariant, string> = {
+  dark: "text-gray-200",
+  light: "text-gray-700",
+};

--- a/components/general/MobileAside.tsx
+++ b/components/general/MobileAside.tsx
@@ -1,7 +1,6 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { FaBars, FaTimes } from "react-icons/fa";
-import { motion, AnimatePresence } from "framer-motion";
 import { Aside } from "@/components/general/Aside";
 import { IuserInfo } from "@/types/general";
 
@@ -11,60 +10,95 @@ export const MobileAsideToggle = ({
   profileInfo: IuserInfo;
 }) => {
   const [isAsideOpen, setIsAsideOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const openerRef = useRef<HTMLButtonElement>(null);
+  const hasBeenOpened = useRef(false);
 
-  const toggleAside = () => {
-    setIsAsideOpen(!isAsideOpen);
-  };
+  const toggleAside = () => setIsAsideOpen((open) => !open);
+
+  // Close on Escape and lock background scrolling while the drawer is open.
+  useEffect(() => {
+    if (!isAsideOpen) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setIsAsideOpen(false);
+    };
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    document.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [isAsideOpen]);
+
+  // Move focus into the drawer when it opens, and back to the toggle on close,
+  // so keyboard users are not stranded behind the overlay.
+  useEffect(() => {
+    if (isAsideOpen) {
+      hasBeenOpened.current = true;
+      panelRef.current?.focus();
+    } else if (hasBeenOpened.current) {
+      // Guarded: without this the first render would steal focus to the menu
+      // button on every page load.
+      openerRef.current?.focus({ preventScroll: true });
+    }
+  }, [isAsideOpen]);
 
   return (
     <>
       {/* Mobile Menu Toggle */}
       {!isAsideOpen && (
         <button
+          ref={openerRef}
           onClick={toggleAside}
-          className={`
-          lg:hidden fixed top-4 left-4 z-[1000] 
-          bg-blue-600 text-white p-2 rounded-md
-          transition-all duration-300
-        `}
+          aria-label="Open navigation menu"
+          aria-expanded={isAsideOpen}
+          className="lg:hidden fixed top-4 left-4 z-[1000] bg-blue-600 text-white p-2 rounded-md transition-all duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-primary-light"
         >
-          <FaBars />
+          <FaBars aria-hidden="true" />
         </button>
       )}
 
-      {/* Mobile Layout */}
-      <AnimatePresence>
-        {isAsideOpen && (
-          <motion.div
-            initial={{ x: "-100%" }}
-            animate={{ x: 0 }}
-            exit={{ x: "-100%" }}
-            transition={{ type: "tween" }}
-            className="
-              fixed inset-0 z-50 
-              lg:hidden
-              w-[80%] max-w-[300px]
-              rounded-r-xl
-            "
-          >
-            <div className="h-full overflow-y-auto ">
-              <Aside
-                setIsAsideOpen={setIsAsideOpen}
-                profileInfo={profileInfo}
-              />
-            </div>
-            <button
-              onClick={toggleAside}
-              className="
-                absolute top-4 right-5 z-[1000]
-                bg-red-600 text-white p-2 rounded-md
-              "
-            >
-              <FaTimes />
-            </button>
-          </motion.div>
-        )}
-      </AnimatePresence>
+      {/*
+        A CSS transition plus `inert` rather than AnimatePresence: correctness
+        here does not depend on an exit animation completing, the panel is
+        removed from the tab order and the accessibility tree whenever it is
+        closed, and the prefers-reduced-motion rule in globals.css applies
+        automatically. One fewer moving part for a drawer that only slides.
+      */}
+      <div
+        onClick={() => setIsAsideOpen(false)}
+        aria-hidden="true"
+        className={`fixed inset-0 z-40 bg-black/60 lg:hidden transition-opacity duration-300 ${
+          isAsideOpen ? "opacity-100" : "opacity-0 pointer-events-none"
+        }`}
+      />
+
+      <div
+        ref={panelRef}
+        tabIndex={-1}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Navigation menu"
+        inert={!isAsideOpen}
+        className={`fixed inset-y-0 left-0 z-50 lg:hidden w-[80%] max-w-[300px] rounded-r-xl outline-none transition-transform duration-300 ease-out ${
+          isAsideOpen ? "translate-x-0" : "-translate-x-full"
+        }`}
+      >
+        <div className="h-full overflow-y-auto">
+          <Aside setIsAsideOpen={setIsAsideOpen} profileInfo={profileInfo} />
+        </div>
+        <button
+          onClick={toggleAside}
+          aria-label="Close navigation menu"
+          className="absolute top-4 right-5 z-[1000] bg-red-600 text-white p-2 rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+        >
+          <FaTimes aria-hidden="true" />
+        </button>
+      </div>
     </>
   );
 };

--- a/components/general/chatbot/ChatHeader.tsx
+++ b/components/general/chatbot/ChatHeader.tsx
@@ -22,9 +22,10 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({ onClose }) => {
       </div>
       <button
         onClick={onClose}
-        className="p-1 hover:bg-white/10 rounded-full transition-colors"
+        aria-label="Close chat"
+        className="p-1 hover:bg-white/10 rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
       >
-        <IoClose size={24} />
+        <IoClose size={24} aria-hidden="true" />
       </button>
     </div>
   );

--- a/components/general/chatbot/ChatInput.tsx
+++ b/components/general/chatbot/ChatInput.tsx
@@ -26,10 +26,11 @@ export const ChatInput: React.FC<ChatInputProps> = ({
       />
       <button
         onClick={onSend}
+        aria-label="Send message"
         disabled={isLoading || !input.trim()}
         className="w-10 h-10 rounded-full bg-blue-600 text-white flex items-center justify-center hover:bg-blue-700 transition-all shadow-md disabled:bg-gray-300 disabled:shadow-none"
       >
-        <IoSend size={18} />
+        <IoSend size={18} aria-hidden="true" />
       </button>
     </div>
   );

--- a/components/general/chatbot/ChatToggle.tsx
+++ b/components/general/chatbot/ChatToggle.tsx
@@ -13,12 +13,13 @@ export const ChatToggle: React.FC<ChatToggleProps> = ({ onClick }) => {
       whileHover={{ scale: 1.05 }}
       whileTap={{ scale: 0.95 }}
       onClick={onClick}
+      aria-label="Open chat assistant"
       className={clsx(
         "w-14 h-14 rounded-full flex items-center justify-center shadow-2xl transition-all duration-300",
         "bg-gradient-to-br from-blue-600 to-indigo-700 text-white",
       )}
     >
-      <IoChatbubbleEllipses size={30} />
+      <IoChatbubbleEllipses size={30} aria-hidden="true" />
     </motion.button>
   );
 };

--- a/types/forms.ts
+++ b/types/forms.ts
@@ -18,13 +18,24 @@ export interface FormProps<T extends FieldValues> {
   };
 }
 
+/**
+ * "dark"  — the public site's glass-on-navy fields (default)
+ * "light" — the dashboard's white cards
+ *
+ * Replaces the `.input-light` / `.input-dark` `!important` overrides that
+ * previously fought the component's own hardcoded styling.
+ */
+export type FieldVariant = "dark" | "light";
+
 // input filed props
 export interface InputFieldProps {
   name: string;
   label: string;
   type?: string;
   className?: string;
-  value?: string;
+  variant?: FieldVariant;
+  /** Render the label visually but keep it for screen readers when false. */
+  showLabel?: boolean;
 }
 // text area props
 export interface TextAreaProps {
@@ -32,6 +43,8 @@ export interface TextAreaProps {
   label: string;
   rows?: number;
   className?: string;
+  variant?: FieldVariant;
+  showLabel?: boolean;
 }
 
 // submit button props


### PR DESCRIPTION
Item 17 (partial) and the accessibility findings from the audit.

1. Every form field now has a real label InputField and TextArea relied on placeholders alone. A placeholder is not an accessible name and it disappears as soon as the user types, so a half-filled field had nothing to announce. Both now render a <label htmlFor> tied to the input's id — visible in the dashboard, visually hidden (sr-only) on the public site so the existing look is unchanged.

   Errors are wired up properly: aria-invalid on the field, aria-describedby pointing at the message, and role="alert" on the message itself.

   Verified in a browser by submitting the contact form empty — all four fields reported aria-invalid="true" with aria-describedby resolving to a role="alert" element carrying the right message.

2. Replace the `!important` styling hack with a `variant` prop InputField hardcoded dark styling, so the dashboard fought it with an .input-light class of five `!important` overrides, applied field by field across eleven forms — and inconsistently: PersonalForm used three different spellings of the same intent.

   Fields now take variant="dark" | "light" (default dark), with the shared rules in components/forms/fieldStyles.ts. The .input-light/.input-dark block is deleted from globals.css and all eleven forms migrated.

   Also drops the unused `value` prop, which fought register() by making the input controlled without an onChange.

3. Associate the upload inputs' labels ImageUploadInput and FileUploadInput each rendered a <label> with no htmlFor — an orphan pointing at nothing. Both now reference their file input's id.

4. Mobile navigation drawer It had no backdrop, no click-outside, no Escape handler, no scroll lock and no focus management, and its links stayed reachable while off-screen.

   Adds a dimming backdrop that closes on tap, Escape-to-close, background scroll locking, focus moved into the drawer on open and returned to the toggle on close, and role="dialog" / aria-modal / aria-label / aria-expanded.

   Implemented with a CSS transition and `inert` rather than AnimatePresence: correctness no longer depends on an exit animation completing, and the panel leaves the tab order and accessibility tree whenever it is closed. Verified: closed -> inert, its 8 links unreachable by focus; open -> not inert, links focusable, background scroll locked; Escape -> inert again, scroll restored, focus back on the toggle, and no focus stolen on load.

5. aria-labels on icon-only buttons The chat toggle, chat close and send buttons had no accessible name.

6. Stop global-error.tsx importing next/error next/error is a pages-router component, so rendering it makes the build resolve /_document, which does not exist in an app-router-only project. The build failed with "Cannot find module for page: /_document" as soon as an unrelated change shifted webpack chunking. It also rendered a bare unstyled page with statusCode 0. Replaced with real markup in the site's colours, keeping the Sentry capture and adding a retry button.

Verified: tsc clean, `eslint .` clean, production build clean.