### PR TITLE
feat(dashboard): add a link back to the public site

### DIFF
--- a/components/dashboard/Header.tsx
+++ b/components/dashboard/Header.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { FaBars } from "react-icons/fa";
+import { FaBars, FaArrowLeft } from "react-icons/fa";
 import { type Dispatch, type SetStateAction } from "react";
+import Link from "next/link";
 import LogoutButton from "./LogoutButton";
 
 export default function Header({
@@ -13,7 +14,17 @@ export default function Header({
     <header className="bg-white shadow-sm top-0 z-10 sticky">
       <div className="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8 flex justify-between items-center">
         <h1 className="text-2xl font-semibold text-gray-900">Dashboard</h1>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1 sm:gap-2">
+          {/* Way back to the public site. The dashboard had no route out of
+              itself short of editing the URL. */}
+          <Link
+            href="/"
+            className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-secondary-light"
+          >
+            <FaArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+            <span className="hidden sm:inline">View site</span>
+            <span className="sr-only sm:hidden">View site</span>
+          </Link>
           <LogoutButton />
           <button
             onClick={() => setSidebarOpen(true)}


### PR DESCRIPTION
The dashboard had no way out of itself. Once inside, the only routes were between its own sections or Sign out — returning to the portfolio meant editing the URL by hand.

Adds a "View site" link to the dashboard header, beside Sign out, so it is present on every dashboard page. The arrow-left icon and wording say where it goes rather than naming a route.

The label collapses to an icon below sm to leave room for Sign out and the menu toggle on narrow screens, with an sr-only label so the link keeps an accessible name when the text is hidden.

Verified with an admin cookie on a dev server: the link renders on /dashboard, /dashboard/projects and /dashboard/skills, pointing at "/".