### PR TITLE
fix(home): count the technologies figure from skills, not project tags

### DIFF
--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -4,20 +4,25 @@ import { SocialLinks } from "@/components/Home/SocialLinks";
 import { HomeIntro } from "@/components/Home/HomeIntro";
 import { getProfileInfo } from "@/actions/getProfileInfo";
 import { getAllProjects } from "@/actions/getAllProjects";
+import { getAllSkills } from "@/actions/getAllSkills";
 import { IuserInfo } from "@/types/general";
 
 export default async function Home() {
-  const [profileInfo, projects] = await Promise.all([
+  const [profileInfo, projects, skills] = await Promise.all([
     getProfileInfo(),
     getAllProjects(),
+    getAllSkills(),
   ]);
 
-  const list = projects ?? [];
-  const technologies = new Set(
-    list.flatMap((project) =>
-      (project.technologies ?? []).map((tech) => tech.trim().toLowerCase()),
-    ),
-  );
+  // Both figures are counted from the data the site already serves, so they
+  // move on their own as projects and skills are added.
+  //
+  // The technology count comes from the skills collection rather than from
+  // the tags on projects: the skills list is the canonical one, while the
+  // project tags contain duplicates across projects and a few typos
+  // ("Talwindcss", "Expres.js") that would inflate a unique count.
+  const projectCount = (projects ?? []).length;
+  const skillCount = (skills ?? []).length;
 
   return (
     /*
@@ -43,8 +48,8 @@ export default async function Home() {
       <div className="relative z-10 w-full py-6">
         <HomeIntro
           profileInfo={profileInfo as IuserInfo}
-          projectCount={list.length}
-          technologyCount={technologies.size}
+          projectCount={projectCount}
+          technologyCount={skillCount}
         />
 
         <div className="mt-9 flex flex-wrap items-center gap-x-4 gap-y-4 pl-6 sm:pl-10">

--- a/components/Home/HomeIntro.tsx
+++ b/components/Home/HomeIntro.tsx
@@ -41,7 +41,9 @@ export const HomeIntro = ({
 
   const figures = [
     { value: projectCount, label: "projects shipped" },
-    { value: technologyCount, label: "technologies used" },
+    // Counted from the skills collection, so "used" would overstate it —
+    // these are the technologies worked with, not ones tallied per project.
+    { value: technologyCount, label: "technologies" },
   ];
 
   return (


### PR DESCRIPTION
Both hero figures were already computed rather than typed, but the second one derived from the technology tags on projects, deduplicated case-insensitively. That is the wrong source.

The skills collection is the canonical list of what the work is done with. The project tags are per-project labels, and they carry the noise you would expect of free text entered many times: duplicates across projects, case variants, and two typos — "Talwindcss" and "Expres.js" — each of which counted as its own technology and inflated the total.

The figure now reads skills.length, fetched alongside the profile and projects in the same Promise.all, so the hero still makes one round of requests.

The label drops "used" with it: counted from skills, these are technologies worked with, not ones tallied per project.

Verified against the live API: it reports 10 projects and 31 skills, and the rendered page shows "projects shipped 10 / technologies 31". The skills count had already moved from 26 to 31 since the figure was added, which is the point — both numbers track the data on their own.